### PR TITLE
Quick workaround for FOREIGN_KEY_CHECKS

### DIFF
--- a/mydumper.c
+++ b/mydumper.c
@@ -2595,6 +2595,10 @@ void dump_schema_data(MYSQL *conn, char *database, char *table, char *filename) 
 		if (!skip_tz) {
 			g_string_append(statement,"/*!40103 SET TIME_ZONE='+00:00' */;\n");
 		}
+	} elseif (detected_server == SERVER_TYPE_TIDB) {
+		if (!skip_tz) {
+			g_string_append(statement,"/*!40103 SET TIME_ZONE='+00:00' */;\n");
+		}
 	} else {
 		g_string_printf(statement, "SET FOREIGN_KEY_CHECKS=0;\n");
 	}

--- a/mydumper.c
+++ b/mydumper.c
@@ -2595,7 +2595,7 @@ void dump_schema_data(MYSQL *conn, char *database, char *table, char *filename) 
 		if (!skip_tz) {
 			g_string_append(statement,"/*!40103 SET TIME_ZONE='+00:00' */;\n");
 		}
-	} elseif (detected_server == SERVER_TYPE_TIDB) {
+	} else if (detected_server == SERVER_TYPE_TIDB) {
 		if (!skip_tz) {
 			g_string_append(statement,"/*!40103 SET TIME_ZONE='+00:00' */;\n");
 		}
@@ -3024,6 +3024,10 @@ guint64 dump_table_data(MYSQL * conn, FILE *file, char *database, char *table, c
 				if (detected_server == SERVER_TYPE_MYSQL) {
 					g_string_printf(statement,"/*!40101 SET NAMES binary*/;\n");
 					g_string_append(statement,"/*!40014 SET FOREIGN_KEY_CHECKS=0*/;\n");
+					if (!skip_tz) {
+					  g_string_append(statement,"/*!40103 SET TIME_ZONE='+00:00' */;\n");
+					}
+				} else if (detected_server == SERVER_TYPE_TIDB) {
 					if (!skip_tz) {
 					  g_string_append(statement,"/*!40103 SET TIME_ZONE='+00:00' */;\n");
 					}


### PR DESCRIPTION
Syntax without version detection does not work with `loader`.

Also sets the time_zone correctly in the restore file.