### PR TITLE
include git commit hash into `mydumper -V`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,13 @@ project(mydumper)
 set(VERSION 0.9.5)
 set(ARCHIVE_NAME "${CMAKE_PROJECT_NAME}-${VERSION}")
 
+execute_process(
+  COMMAND git rev-parse HEAD
+  WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+  OUTPUT_VARIABLE GIT_COMMIT_HASH
+  OUTPUT_STRIP_TRAILING_WHITESPACE
+)
+
 #Required packages
 set(CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake/modules)
 find_package(MySQL)

--- a/config.h.in
+++ b/config.h.in
@@ -2,6 +2,7 @@
 #define CONFIG_H
 
 #cmakedefine VERSION "@VERSION@"
+#cmakedefine GIT_COMMIT_HASH "@GIT_COMMIT_HASH@"
 #cmakedefine WITH_BINLOG
 #cmakedefine WITH_SSL
 

--- a/mydumper.c
+++ b/mydumper.c
@@ -941,7 +941,7 @@ int main(int argc, char *argv[])
 	//printf("your password is %s and the size is %d \n",password,sizeof(password));
 
 	if (program_version) {
-		g_print("mydumper %s, built against MySQL %s\n", VERSION, MYSQL_VERSION_STR);
+		g_print("mydumper %s (%s), built against MySQL %s\n", VERSION, GIT_COMMIT_HASH, MYSQL_VERSION_STR);
 		exit (EXIT_SUCCESS);
 	}
 

--- a/myloader.c
+++ b/myloader.c
@@ -127,7 +127,7 @@ int main(int argc, char *argv[]) {
 	}
 
 	if (program_version) {
-		g_print("myloader %s, built against MySQL %s\n", VERSION, MYSQL_VERSION_STR);
+		g_print("myloader %s (%s), built against MySQL %s\n", VERSION, GIT_COMMIT_HASH, MYSQL_VERSION_STR);
 		exit(EXIT_SUCCESS);
 	}
 


### PR DESCRIPTION
Since we almost never change the version number, this helps us accurately find out which version of mydumper the customers are using.