### PR TITLE
pre resolve host before mysql_real_connect

### DIFF
--- a/common.h
+++ b/common.h
@@ -1,4 +1,4 @@
-/* 
+/*
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation, either version 3 of the License, or
@@ -18,6 +18,8 @@
 #define _common_h
 
 char *hostname=NULL;
+GArray *resolve_ips=NULL;
+int resolve_ip_count = 0;
 char *username=NULL;
 char *password=NULL;
 char *socket_path=NULL;

--- a/common.h
+++ b/common.h
@@ -19,7 +19,6 @@
 
 char *hostname=NULL;
 GArray *resolve_ips=NULL;
-int resolve_ip_count = 0;
 char *username=NULL;
 char *password=NULL;
 char *socket_path=NULL;

--- a/connection.c
+++ b/connection.c
@@ -1,4 +1,4 @@
-/* 
+/*
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation, either version 3 of the License, or
@@ -18,8 +18,12 @@
 #include <pcre.h>
 #include <glib.h>
 #include <string.h>
+#include <netdb.h>
+#include <sys/socket.h>
+#include <arpa/inet.h>
 #include "connection.h"
 
+extern GArray *resolve_ips;
 extern char *defaults_file;
 #ifdef WITH_SSL
 extern char *key;
@@ -51,4 +55,59 @@ void configure_connection(MYSQL *conn, const char *name) {
 	mysql_ssl_set(conn,key,cert,ca,capath,cipher);
 	mysql_options(conn,MYSQL_OPT_SSL_MODE,&i);
 #endif
+}
+
+void pre_resolve_host(const char *host) {
+	if (host == NULL) {
+		return;
+	}
+
+	struct addrinfo hints, *res;
+	int errcode;
+	char addrstr[100];
+	void *ptr;
+
+	memset(&hints, 0, sizeof(hints));
+	hints.ai_family = PF_UNSPEC;
+	hints.ai_socktype = SOCK_STREAM;
+
+	errcode = getaddrinfo(host, NULL, &hints, &res);
+	if (errcode != 0) {
+		g_critical("failed to resolve host %s\n", host);
+		exit(EXIT_FAILURE);
+	}
+
+	while (res) {
+		if (res->ai_family == AF_INET6) {
+			ptr = &((struct sockaddr_in6 *) res->ai_addr)->sin6_addr;
+		} else if (res->ai_family == AF_INET) {
+			ptr = &((struct sockaddr_in *) res->ai_addr)->sin_addr;
+		} else {
+			g_warning("skip unsupport ai_family: %d", res->ai_family);
+			continue;
+		}
+		inet_ntop(res->ai_family, ptr, addrstr, 100);
+		char *addrptr = g_strndup(addrstr, strlen(addrstr));
+		g_array_append_val(resolve_ips, addrptr);
+		res = res->ai_next;
+	}
+}
+
+MYSQL *mysql_connect_wrap(MYSQL *mysql, const char *user, const char *passwd,
+                          const char *connect_db, unsigned int db_port,
+                          const char *unix_socket, unsigned long client_flag) {
+
+	if (resolve_ips == NULL || resolve_ips->len == 0) {
+		return mysql_real_connect(mysql, NULL, user, passwd, connect_db, db_port, unix_socket, client_flag);
+	}
+	guint i = 0;
+	for(; i < resolve_ips->len; ++i) {
+		char *ip = g_array_index(resolve_ips, char*, i);
+		if(!mysql_real_connect(mysql, ip, user, passwd, connect_db, db_port, unix_socket, client_flag)) {
+			g_warning("Failed to connect to ip: %s error: %s", ip, mysql_error(mysql));
+		} else {
+			return mysql;
+		}
+	}
+	return NULL;
 }

--- a/connection.c
+++ b/connection.c
@@ -83,7 +83,7 @@ void pre_resolve_host(const char *host) {
 		} else if (res->ai_family == AF_INET) {
 			ptr = &((struct sockaddr_in *) res->ai_addr)->sin_addr;
 		} else {
-			g_warning("skip unsupport ai_family: %d", res->ai_family);
+			g_warning("skip unsupported ai_family: %d", res->ai_family);
 			continue;
 		}
 		inet_ntop(res->ai_family, ptr, addrstr, 100);

--- a/connection.h
+++ b/connection.h
@@ -1,4 +1,4 @@
-/* 
+/*
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation, either version 3 of the License, or
@@ -19,4 +19,7 @@
 #include <mysql.h>
 
 void configure_connection(MYSQL *conn, const char* name);
+void pre_resolve_host(const char *host);
+MYSQL *mysql_connect_wrap(MYSQL *mysql, const char *user, const char *passwd, const char *db, unsigned int port,
+                          const char *unix_socket, unsigned long client_flag);
 #endif

--- a/mydumper.c
+++ b/mydumper.c
@@ -910,6 +910,10 @@ MYSQL *reconnect_for_binlog(MYSQL *thrconn) {
 #endif
 
 void pre_resolve_host(const char *host) {
+	if (host == NULL) {
+		return;
+	}
+
 	struct addrinfo hints, *res;
 	int errcode;
 	char addrstr[100];
@@ -944,6 +948,9 @@ MYSQL *mysql_connect_wrap(MYSQL *mysql, const char *user, const char *passwd,
                           const char *connect_db, unsigned int db_port,
                           const char *unix_socket, unsigned long client_flag) {
 
+	if (resolve_ip_count == 0) {
+		return mysql_real_connect(mysql, NULL, user, passwd, connect_db, db_port, unix_socket, client_flag);
+	}
 	int i = 0;
 	for(; i < resolve_ip_count; ++i) {
 		char *ip = g_array_index(resolve_ips, char*, i);

--- a/mydumper.c
+++ b/mydumper.c
@@ -922,7 +922,6 @@ void pre_resolve_host(const char *host) {
 	memset(&hints, 0, sizeof(hints));
 	hints.ai_family = PF_UNSPEC;
 	hints.ai_socktype = SOCK_STREAM;
-	hints.ai_flags |= AI_CANONNAME;
 
 	errcode = getaddrinfo(host, NULL, &hints, &res);
 	if (errcode != 0) {

--- a/mydumper.c
+++ b/mydumper.c
@@ -39,9 +39,6 @@
 #include <pcre.h>
 #include <signal.h>
 #include <glib/gstdio.h>
-#include <netdb.h>
-#include <sys/socket.h>
-#include <arpa/inet.h>
 #include "config.h"
 #ifdef WITH_BINLOG
 #include "binlog.h"
@@ -228,9 +225,6 @@ void start_dump(MYSQL *conn);
 MYSQL *create_main_connection();
 void *exec_thread(void *data);
 void write_log_file(const gchar *log_domain, GLogLevelFlags log_level, const gchar *message, gpointer user_data);
-void pre_resolve_host(const char *host);
-MYSQL *mysql_connect_wrap(MYSQL *mysql, const char *user, const char *passwd, const char *db, unsigned int port,
-                          const char *unix_socket, unsigned long client_flag);
 
 void no_log(const gchar *log_domain, GLogLevelFlags log_level, const gchar *message, gpointer user_data) {
 	(void) log_domain;
@@ -908,61 +902,6 @@ MYSQL *reconnect_for_binlog(MYSQL *thrconn) {
 	return thrconn;
 }
 #endif
-
-void pre_resolve_host(const char *host) {
-	if (host == NULL) {
-		return;
-	}
-
-	struct addrinfo hints, *res;
-	int errcode;
-	char addrstr[100];
-	void *ptr;
-
-	memset(&hints, 0, sizeof(hints));
-	hints.ai_family = PF_UNSPEC;
-	hints.ai_socktype = SOCK_STREAM;
-
-	errcode = getaddrinfo(host, NULL, &hints, &res);
-	if (errcode != 0) {
- 		g_print("failed to resolve host %s\n", host);
-		exit(EXIT_FAILURE);
-	}
-
-	while (res) {
-		if (res->ai_family == AF_INET6) {
-			ptr = &((struct sockaddr_in6 *) res->ai_addr)->sin6_addr;
-		} else if (res->ai_family == AF_INET) {
-			ptr = &((struct sockaddr_in *) res->ai_addr)->sin_addr;
-		} else {
-			g_warning("skip unsupport ai_family: %d", res->ai_family);
-			continue;
-		}
-		inet_ntop(res->ai_family, ptr, addrstr, 100);
-		char *addrptr = g_strndup(addrstr, strlen(addrstr));
-		g_array_append_val(resolve_ips, addrptr);
-		res = res->ai_next;
-	}
-}
-
-MYSQL *mysql_connect_wrap(MYSQL *mysql, const char *user, const char *passwd,
-                          const char *connect_db, unsigned int db_port,
-                          const char *unix_socket, unsigned long client_flag) {
-
-	if (resolve_ips == NULL || resolve_ips->len == 0) {
-		return mysql_real_connect(mysql, NULL, user, passwd, connect_db, db_port, unix_socket, client_flag);
-	}
-	guint i = 0;
-	for(; i < resolve_ips->len; ++i) {
-		char *ip = g_array_index(resolve_ips, char*, i);
-		if(!mysql_real_connect(mysql, ip, user, passwd, connect_db, db_port, unix_socket, client_flag)) {
-			g_warning("Failed to connect to ip: %s error: %s", ip, mysql_error(mysql));
-		} else {
-			return mysql;
-		}
-	}
-	return NULL;
-}
 
 int main(int argc, char *argv[])
 {

--- a/myloader.c
+++ b/myloader.c
@@ -131,6 +131,10 @@ int main(int argc, char *argv[]) {
 		exit(EXIT_SUCCESS);
 	}
 
+	// resolve hostname if possible
+	resolve_ips = g_array_new(FALSE, FALSE, sizeof(char *));
+	pre_resolve_host(hostname);
+
 	set_verbose(verbose);
 
 	if (!directory) {
@@ -147,7 +151,7 @@ int main(int argc, char *argv[]) {
 	conn= mysql_init(NULL);
 
 	configure_connection(conn,"myloader");
-	if (!mysql_real_connect(conn, hostname, username, password, NULL, port, socket_path, 0)) {
+	if (!mysql_connect_wrap(conn, username, password, NULL, port, socket_path, 0)) {
 		g_critical("Error connection to database: %s", mysql_error(conn));
 		exit(EXIT_FAILURE);
 	}
@@ -424,7 +428,7 @@ void *process_queue(struct thread_data *td) {
 
 	configure_connection(thrconn,"myloader");
 
-	if (!mysql_real_connect(thrconn, hostname, username, password, NULL, port, socket_path, 0)) {
+	if (!mysql_connect_wrap(thrconn, username, password, NULL, port, socket_path, 0)) {
 		g_critical("Failed to connect to MySQL server: %s", mysql_error(thrconn));
 		exit(EXIT_FAILURE);
 	}


### PR DESCRIPTION
### What problem does this PR solve?
use hostname in mydumper will lead to Segmentation fault
This is because we use static link during building and getaddrinfo causes segfault if multithreaded. ref: https://bugzilla.redhat.com/show_bug.cgi?id=523694

### What is changed and how it works?
- pre resolve hostname and store them in a global variable, we don't need to resolve it each time.
- wrap `mysql_real_connect`, loop for each resolved ips until find one can connect to.

### Check List

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)
    - test `-h hostname`
    - test `-h ip`
    - test no host provided
