### PR TITLE
fix generated column check in information_schema extra field

### DIFF
--- a/mydumper.c
+++ b/mydumper.c
@@ -1796,7 +1796,7 @@ MYSQL_STMT *execute_detect_fields_stmt(MYSQL *conn, char *database, char *table,
 }
 
 gboolean detect_generated_fields(MYSQL *conn, char *database, char *table){
-	const char* query = "select 1 from information_schema.COLUMNS where TABLE_SCHEMA=? and TABLE_NAME=? and extra like '%GENERATED%'";
+	const char* query = "select 1 from information_schema.COLUMNS where TABLE_SCHEMA=? and TABLE_NAME=? and extra REGEXP 'STORED|VIRTUAL GENERATED'";
 	MYSQL_STMT *stmt = execute_detect_fields_stmt(conn, database, table, query);
 	if (!stmt) {
 		return FALSE;
@@ -1861,7 +1861,7 @@ void append_escaped_identifier(GString *str, const gchar *identifier) {
 }
 
 GString * get_insertable_fields(MYSQL *conn, char *database, char *table){
-	const char* query = "select COLUMN_NAME from information_schema.COLUMNS where TABLE_SCHEMA=? and TABLE_NAME=? and extra not like '%GENERATED%'";
+	const char* query = "select COLUMN_NAME from information_schema.COLUMNS where TABLE_SCHEMA=? and TABLE_NAME=? and extra NOT REGEXP 'STORED|VIRTUAL GENERATED'";
 	MYSQL_STMT *stmt = execute_detect_fields_stmt(conn, database, table, query);
 	if (!stmt) {
 		return NULL;

--- a/mydumper.c
+++ b/mydumper.c
@@ -1796,7 +1796,7 @@ MYSQL_STMT *execute_detect_fields_stmt(MYSQL *conn, char *database, char *table,
 }
 
 gboolean detect_generated_fields(MYSQL *conn, char *database, char *table){
-	const char* query = "select 1 from information_schema.COLUMNS where TABLE_SCHEMA=? and TABLE_NAME=? and extra REGEXP 'STORED|VIRTUAL GENERATED'";
+	const char* query = "select 1 from information_schema.COLUMNS where TABLE_SCHEMA=? and TABLE_NAME=? and extra REGEXP '(STORED|VIRTUAL) GENERATED'";
 	MYSQL_STMT *stmt = execute_detect_fields_stmt(conn, database, table, query);
 	if (!stmt) {
 		return FALSE;
@@ -1861,7 +1861,7 @@ void append_escaped_identifier(GString *str, const gchar *identifier) {
 }
 
 GString * get_insertable_fields(MYSQL *conn, char *database, char *table){
-	const char* query = "select COLUMN_NAME from information_schema.COLUMNS where TABLE_SCHEMA=? and TABLE_NAME=? and extra NOT REGEXP 'STORED|VIRTUAL GENERATED'";
+	const char* query = "select COLUMN_NAME from information_schema.COLUMNS where TABLE_SCHEMA=? and TABLE_NAME=? and extra NOT REGEXP '(STORED|VIRTUAL) GENERATED'";
 	MYSQL_STMT *stmt = execute_detect_fields_stmt(conn, database, table, query);
 	if (!stmt) {
 		return NULL;


### PR DESCRIPTION
in mysql5.7, [Extra Fields](https://dev.mysql.com/doc/refman/5.7/en/show-columns.html) include:
```
auto_increment for columns that have the AUTO_INCREMENT attribute.
on update CURRENT_TIMESTAMP for TIMESTAMP or DATETIME columns that have the ON UPDATE CURRENT_TIMESTAMP attribute.
VIRTUAL GENERATED or VIRTUAL STORED for generated columns.
```

in mysql8.0, [Extra Fields](https://dev.mysql.com/doc/refman/8.0/en/show-columns.html) include:
```
auto_increment for columns that have the AUTO_INCREMENT attribute.
on update CURRENT_TIMESTAMP for TIMESTAMP or DATETIME columns that have the ON UPDATE CURRENT_TIMESTAMP attribute.
VIRTUAL GENERATED or VIRTUAL STORED for generated columns.
DEFAULT_GENERATED for columns that have an expression default value.
```
I also checked mariadb 10.2, 10.3 have `VIRTUAL GENERATED` and `DEFAULT_GENERATED` too in extra too.

Before this pr, mydumper uses `like '%GENERATED%'` to filter generated column, which will have false positive (treat non-generated column as generated column). We can use more accurate match rule for the generated column.
